### PR TITLE
Initialize segments matrix to improve performance

### DIFF
--- a/Segmentation/segmentSlidingWindow.m
+++ b/Segmentation/segmentSlidingWindow.m
@@ -21,11 +21,13 @@
 function segments = segmentSlidingWindow(data, wSize, sSize)
     len = size(data,1);
     wCurr = 1;
-    segments = []; % todo: init to make faster
+    segments = zeros(ceil((len-wSize)/sSize),2); % improved performance
+    i = 1;
     while (wCurr<len-wSize)
-        segments = [segments; wCurr wCurr+wSize]; % start stop
+        segments(i,:) = [wCurr, wCurr+wSize]; % start, stop
         wCurr = wCurr+sSize; % step forward
+        i = i + 1;
     end
-    segments = [segments; wCurr len]; % add residual
+    segments(end,:) = [wCurr len]; % add residual
 end
 


### PR DESCRIPTION
I noticed the TODO in the `segmentSlidingWindow` function, and thought I can help with this.

The function now initializes the segments matrix with the required size before entering the loop, and uses the counter `i` to select the current row in the matrix to be filled. 

Hope this helps!